### PR TITLE
Customise callback url

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ Rails.application.config.middleware.use OmniAuth::Builder do
                                    provider_name: :saml,
                                    identity_provider_id_regex: /\d+/,
                                    path_prefix: '/auth/saml',
+                                   callback_suffix: 'callback',
                                    # Specify any additional provider specific options
                                    name_identifier_format: 'urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress',
                                    issuer: 'salsify.com',

--- a/lib/omni_auth/multi_provider.rb
+++ b/lib/omni_auth/multi_provider.rb
@@ -13,6 +13,7 @@ module OmniAuth
 
       handler = OmniAuth::MultiProvider::Handler.new(path_prefix: path_prefix,
                                                      identity_provider_id_regex: identity_provider_id_regex,
+                                                     **options,
                                                      &dynamic_options_generator)
 
       static_options = options.merge(path_prefix: path_prefix)

--- a/lib/omni_auth/multi_provider.rb
+++ b/lib/omni_auth/multi_provider.rb
@@ -8,11 +8,9 @@ module OmniAuth
     def self.register(builder,
                       provider_name:,
                       path_prefix: ::OmniAuth.config.path_prefix,
-                      identity_provider_id_regex:,
                       **options, &dynamic_options_generator)
 
       handler = OmniAuth::MultiProvider::Handler.new(path_prefix: path_prefix,
-                                                     identity_provider_id_regex: identity_provider_id_regex,
                                                      **options,
                                                      &dynamic_options_generator)
 

--- a/lib/omni_auth/multi_provider/handler.rb
+++ b/lib/omni_auth/multi_provider/handler.rb
@@ -2,7 +2,7 @@ module OmniAuth
   module MultiProvider
     class Handler
       attr_reader :path_prefix, :provider_instance_path_regex, :request_path_regex,
-                  :callback_path_regex, :callback_postfix,
+                  :callback_path_regex, :callback_suffix,
                   :identity_provider_options_generator
 
       def initialize(path_prefix:,
@@ -16,12 +16,12 @@ module OmniAuth
         @identity_provider_id_regex = identity_provider_id_regex
 
         options = DEFAULT_OPTIONS.merge(options)
-        @callback_postfix = options[:callback_postfix]
+        @callback_suffix = options[:callback_suffix]
 
         # Eagerly compute these since lazy evaluation will not be threadsafe
         @provider_instance_path_regex = /^#{@path_prefix}\/(?<identity_provider_id>#{@identity_provider_id_regex})/
         @request_path_regex = /#{@provider_instance_path_regex}\/?$/
-        @callback_path_regex = /#{@provider_instance_path_regex}\/#{@callback_postfix}\/?$/
+        @callback_path_regex = /#{@provider_instance_path_regex}\/#{@callback_suffix}\/?$/
       end
 
       def provider_options
@@ -54,13 +54,13 @@ module OmniAuth
       private
 
       DEFAULT_OPTIONS = {
-        callback_postfix: 'callback'
+        callback_suffix: 'callback'
       }.freeze
 
       def add_path_options(strategy, identity_provider_id)
         strategy.options.merge!(
           request_path: "#{path_prefix}/#{identity_provider_id}",
-          callback_path: "#{path_prefix}/#{identity_provider_id}/#{callback_postfix}"
+          callback_path: "#{path_prefix}/#{identity_provider_id}/#{callback_suffix}"
         )
       end
 

--- a/lib/omni_auth/multi_provider/handler.rb
+++ b/lib/omni_auth/multi_provider/handler.rb
@@ -7,16 +7,15 @@ module OmniAuth
 
       def initialize(path_prefix:,
                      identity_provider_id_regex:,
-                     **options,
+                     callback_suffix: 'callback',
+                     **_options,
                      &identity_provider_options_generator)
         raise 'Missing provider options generator block' unless block_given?
 
         @path_prefix = path_prefix
         @identity_provider_options_generator = identity_provider_options_generator
         @identity_provider_id_regex = identity_provider_id_regex
-
-        options = DEFAULT_OPTIONS.merge(options)
-        @callback_suffix = options[:callback_suffix]
+        @callback_suffix = callback_suffix
 
         # Eagerly compute these since lazy evaluation will not be threadsafe
         @provider_instance_path_regex = /^#{@path_prefix}\/(?<identity_provider_id>#{@identity_provider_id_regex})/
@@ -52,10 +51,6 @@ module OmniAuth
       end
 
       private
-
-      DEFAULT_OPTIONS = {
-        callback_suffix: 'callback'
-      }.freeze
 
       def add_path_options(strategy, identity_provider_id)
         strategy.options.merge!(

--- a/lib/omni_auth/multi_provider/handler.rb
+++ b/lib/omni_auth/multi_provider/handler.rb
@@ -2,8 +2,7 @@ module OmniAuth
   module MultiProvider
     class Handler
       attr_reader :path_prefix, :provider_instance_path_regex, :request_path_regex,
-                  :callback_path_regex, :provider_path_prefix,
-                  :identity_provider_options_generator
+                  :callback_path_regex, :identity_provider_options_generator
 
       def initialize(path_prefix:,
                      identity_provider_id_regex:,
@@ -15,7 +14,6 @@ module OmniAuth
         @identity_provider_id_regex = identity_provider_id_regex
 
         # Eagerly compute these since lazy evaluation will not be threadsafe
-        @provider_path_prefix = @path_prefix
         @provider_instance_path_regex = /^#{@path_prefix}\/(?<identity_provider_id>#{@identity_provider_id_regex})/
         @request_path_regex = /#{@provider_instance_path_regex}\/?$/
         @callback_path_regex = /#{@provider_instance_path_regex}\/callback\/?$/
@@ -52,8 +50,8 @@ module OmniAuth
 
       def add_path_options(strategy, identity_provider_id)
         strategy.options.merge!(
-          request_path: "#{provider_path_prefix}/#{identity_provider_id}",
-          callback_path: "#{provider_path_prefix}/#{identity_provider_id}/callback"
+          request_path: "#{path_prefix}/#{identity_provider_id}",
+          callback_path: "#{path_prefix}/#{identity_provider_id}/callback"
         )
       end
 

--- a/lib/omni_auth/multi_provider/handler.rb
+++ b/lib/omni_auth/multi_provider/handler.rb
@@ -2,10 +2,12 @@ module OmniAuth
   module MultiProvider
     class Handler
       attr_reader :path_prefix, :provider_instance_path_regex, :request_path_regex,
-                  :callback_path_regex, :identity_provider_options_generator
+                  :callback_path_regex, :callback_postfix,
+                  :identity_provider_options_generator
 
       def initialize(path_prefix:,
                      identity_provider_id_regex:,
+                     **options,
                      &identity_provider_options_generator)
         raise 'Missing provider options generator block' unless block_given?
 
@@ -13,10 +15,13 @@ module OmniAuth
         @identity_provider_options_generator = identity_provider_options_generator
         @identity_provider_id_regex = identity_provider_id_regex
 
+        options = DEFAULT_OPTIONS.merge(options)
+        @callback_postfix = options[:callback_postfix]
+
         # Eagerly compute these since lazy evaluation will not be threadsafe
         @provider_instance_path_regex = /^#{@path_prefix}\/(?<identity_provider_id>#{@identity_provider_id_regex})/
         @request_path_regex = /#{@provider_instance_path_regex}\/?$/
-        @callback_path_regex = /#{@provider_instance_path_regex}\/callback\/?$/
+        @callback_path_regex = /#{@provider_instance_path_regex}\/#{@callback_postfix}\/?$/
       end
 
       def provider_options
@@ -48,10 +53,14 @@ module OmniAuth
 
       private
 
+      DEFAULT_OPTIONS = {
+        callback_postfix: 'callback'
+      }.freeze
+
       def add_path_options(strategy, identity_provider_id)
         strategy.options.merge!(
           request_path: "#{path_prefix}/#{identity_provider_id}",
-          callback_path: "#{path_prefix}/#{identity_provider_id}/callback"
+          callback_path: "#{path_prefix}/#{identity_provider_id}/#{callback_postfix}"
         )
       end
 

--- a/spec/omni_auth/multi_provider/handler_spec.rb
+++ b/spec/omni_auth/multi_provider/handler_spec.rb
@@ -151,7 +151,7 @@ describe OmniAuth::MultiProvider::Handler do
     describe "custom callback_path" do
       let(:handler_options) do
         {
-          callback_postfix: "wow"
+          callback_postfix: 'wow'
         }
       end
 

--- a/spec/omni_auth/multi_provider/handler_spec.rb
+++ b/spec/omni_auth/multi_provider/handler_spec.rb
@@ -151,7 +151,7 @@ describe OmniAuth::MultiProvider::Handler do
     describe "custom callback_path" do
       let(:handler_options) do
         {
-          callback_postfix: 'wow'
+          callback_suffix: 'wow'
         }
       end
 

--- a/spec/omni_auth/multi_provider/handler_spec.rb
+++ b/spec/omni_auth/multi_provider/handler_spec.rb
@@ -11,7 +11,11 @@ describe OmniAuth::MultiProvider::Handler do
 
   let(:path_prefix) { '/auth/saml' }
   let(:handler) do
-    described_class.new(path_prefix: path_prefix, identity_provider_id_regex: /\d+/, &provider_options_generator)
+    described_class.new(path_prefix: path_prefix, identity_provider_id_regex: /\d+/, **handler_options, &provider_options_generator)
+  end
+
+  let(:handler_options) do
+    {}
   end
 
   let(:strategy) do
@@ -143,43 +147,94 @@ describe OmniAuth::MultiProvider::Handler do
   end
 
   describe "#callback_path?" do
-    context "when the path is a callback path" do
-      let(:path) { "#{path_prefix}/#{provider_id}/callback" }
 
-      it "returns true" do
-        expect(handler.callback_path?(env)).to be(true)
+    describe "custom callback_path" do
+      let(:handler_options) do
+        {
+          callback_postfix: "wow"
+        }
+      end
+
+      context "when the path is a callback path" do
+        let(:path) { "#{path_prefix}/#{provider_id}/wow" }
+
+        it "returns true" do
+          expect(handler.callback_path?(env)).to be(true)
+        end
+      end
+
+      context "when the path is a request path" do
+        let(:path) { "#{path_prefix}/#{provider_id}" }
+
+        it "returns false" do
+          expect(handler.callback_path?(env)).to be(false)
+        end
+      end
+
+      context "when the path is a callback path with a trailing segment" do
+        let(:path) { "#{path_prefix}/#{provider_id}/wow/foo" }
+
+        it "returns false" do
+          expect(handler.callback_path?(env)).to be(false)
+        end
+      end
+
+      context "when the path is a callback path with a leading segment" do
+        let(:path) { "/foo#{path_prefix}/#{provider_id}/wow" }
+
+        it "returns false" do
+          expect(handler.callback_path?(env)).to be(false)
+        end
+      end
+
+      context "when the path is a callback path with an invalid provider id" do
+        let(:path) { "#{path_prefix}/foobar/wow" }
+
+        it "returns false" do
+          expect(handler.callback_path?(env)).to be(false)
+        end
       end
     end
 
-    context "when the path is a request path" do
-      let(:path) { "#{path_prefix}/#{provider_id}" }
+    describe "default callback_path" do
+      context "when the path is a callback path" do
+        let(:path) { "#{path_prefix}/#{provider_id}/callback" }
 
-      it "returns false" do
-        expect(handler.callback_path?(env)).to be(false)
+        it "returns true" do
+          expect(handler.callback_path?(env)).to be(true)
+        end
       end
-    end
 
-    context "when the path is a callback path with a trailing segment" do
-      let(:path) { "#{path_prefix}/#{provider_id}/callback/foo" }
+      context "when the path is a request path" do
+        let(:path) { "#{path_prefix}/#{provider_id}" }
 
-      it "returns false" do
-        expect(handler.callback_path?(env)).to be(false)
+        it "returns false" do
+          expect(handler.callback_path?(env)).to be(false)
+        end
       end
-    end
 
-    context "when the path is a callback path with a leading segment" do
-      let(:path) { "/foo#{path_prefix}/#{provider_id}/callback" }
+      context "when the path is a callback path with a trailing segment" do
+        let(:path) { "#{path_prefix}/#{provider_id}/callback/foo" }
 
-      it "returns false" do
-        expect(handler.callback_path?(env)).to be(false)
+        it "returns false" do
+          expect(handler.callback_path?(env)).to be(false)
+        end
       end
-    end
 
-    context "when the path is a callback path with an invalid provider id" do
-      let(:path) { "#{path_prefix}/foobar/callback" }
+      context "when the path is a callback path with a leading segment" do
+        let(:path) { "/foo#{path_prefix}/#{provider_id}/callback" }
 
-      it "returns false" do
-        expect(handler.callback_path?(env)).to be(false)
+        it "returns false" do
+          expect(handler.callback_path?(env)).to be(false)
+        end
+      end
+
+      context "when the path is a callback path with an invalid provider id" do
+        let(:path) { "#{path_prefix}/foobar/callback" }
+
+        it "returns false" do
+          expect(handler.callback_path?(env)).to be(false)
+        end
       end
     end
   end


### PR DESCRIPTION
We are integrating this gem into an existing SAML setup in which the callback urls have already been defined and don't match the pattern of `.../callback`. I have added the ability to provide a custom `callback_postfix` which defaults to the current value but allows someone to override it.